### PR TITLE
feat: add delphi.projectReady context flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,13 +102,23 @@
                 "command": "delphi.run",
                 "title": "Delphi: Run current project",
                 "icon": "$(play)"
+            },
+            {
+                "command": "delphi.configNotReady",
+                "title": "Delphi: Select project config",
+                "icon": "$(loading~spin)"
             }
         ],
         "menus": {
             "editor/title/run": [
                 {
-                    "when": "resourceLangId == objectpascal",
+                    "when": "resourceLangId == objectpascal && delphi.projectReady",
                     "command": "delphi.run",
+                    "group": "navigation"
+                },
+                {
+                    "when": "resourceLangId == objectpascal && !delphi.projectReady",
+                    "command": "delphi.configNotReady",
                     "group": "navigation"
                 }
             ]

--- a/src/client/configFile.ts
+++ b/src/client/configFile.ts
@@ -26,11 +26,13 @@ export async function initConfig() {
         // Get config file
         const configFiles = await collectLSPConfigFiles();
         if (configFiles.length == 0) {
+            commands.executeCommand('setContext', 'delphi.projectReady', false);
             window.showWarningMessage('Delphi: No DelphiLSP project config file were found.');
             updateConfigWithSelectedItem('no_config_available');
         } else if (configFiles.length == 1) {
             updateConfigWithSelectedItem(configFiles[0]);
         } else {
+            commands.executeCommand('setContext', 'delphi.projectReady', false);
             window
                 .showWarningMessage(
                     'Delphi: Multiple DelphiLSP project config files were found. Please select one.',
@@ -44,6 +46,7 @@ export async function initConfig() {
         }
     } else if (!(await fileExists(Uri.parse(configFile)))) {
         // If previously set LSP config file doesn't exist any more, request to select a new one
+        commands.executeCommand('setContext', 'delphi.projectReady', false);
         updateConfigWithSelectedItem('no_config_available');
         window
             .showWarningMessage(
@@ -59,6 +62,7 @@ export async function initConfig() {
             });
     } else {
         // If everything good already, display load message to the user
+        commands.executeCommand('setContext', 'delphi.projectReady', true);
         window.showInformationMessage(
             'Delphi: Loaded configured project ' + path.basename(configFile)
         );
@@ -74,8 +78,10 @@ export async function initConfig() {
 export function updateConfigWithSelectedItem(configFile: UriItem | string) {
     const config = workspace.getConfiguration('delphi');
     if (typeof configFile === 'string') {
+        commands.executeCommand('setContext', 'delphi.projectReady', false);
         config.update('configFile', configFile); // No config file was found
     } else {
+        commands.executeCommand('setContext', 'delphi.projectReady', true);
         config.update('configFile', configFile.uri);
         window.showInformationMessage('Loaded project ' + path.basename(configFile.label));
         initRunScript(configFile.uri); // Init run script for the new project

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext } from 'vscode';
+import { commands, ExtensionContext } from 'vscode';
 import {
     activateLSPClient,
     deactivateLSPClient,
@@ -12,6 +12,7 @@ import registerRunnerCommands from './runner/commands';
  * @param context Context for the extension
  */
 export async function activate(context: ExtensionContext) {
+    commands.executeCommand('setContext', 'delphi.projectReady', false);
     registerLSPCommands(context);
     await activateLSPClient(context);
     registerRunnerCommands(context);

--- a/src/runner/commands.ts
+++ b/src/runner/commands.ts
@@ -21,4 +21,10 @@ export default function registerRunnerCommands(context: ExtensionContext) {
             await initRunScript();
         })
     );
+
+    context.subscriptions.push(
+        commands.registerCommand('delphi.configNotReady', () => {
+            commands.executeCommand('delphi.selectConfigFile');
+        })
+    );
 }


### PR DESCRIPTION
This was annoying me in Cursor as it takes a while to load the extensions and I'd hit the button, and it would do nothing since the extension wasn't fully loaded.

Sets delphi.projectReady to false on activation so a loading spinner appears in the title bar immediately, before the async config check completes. Flips to true/false as the user selects or clears a project via updateConfigWithSelectedItem.

Adds a delphi.configNotReady command (spinning icon) shown in editor/title/run when no project is loaded, replacing the play button until a config is ready.

Made-with: Cursor